### PR TITLE
Provided headers are deleted before sending the request to Microsoft Graph (OAuth2)

### DIFF
--- a/src/destination.js
+++ b/src/destination.js
@@ -32,7 +32,7 @@ function getAuthorizationHeader(_config, cfDestinationInfo) {
     return new Promise((resolve, reject) => {
         var error;
         var config = Object.assign({}, _config);
-        config.headers = {}
+        config.headers = config.headers || {};
         switch (cfDestinationInfo.Authentication) {
             case "NoAuthentication":
                 resolve(config)


### PR DESCRIPTION
### Problem explanation
In order to upload a large file via the MSGraph DriveItems REST API we need to send a custom header (Content-Range) with a PUT request.
During the getAuthorizationHeader function the headers passed with the AxiosConfig object get erased by an initialization.


### Code which exposes the problem

```javascript
const cdsapi = require("@sapmentors/cds-scp-api");

const service = await cdsapi.connect.to('destination');

service.run({
      method: "PUT",
      url: 'https://sn3302.up.1drv.com/up/fe6987415ace7X4e1eF866337',
      headers: {
        "Content-Length": 41024,
        "Content-Range": 'bytes 0-41023/41024',
      },
      data: 'buffer-data-to-be-sent',
})

```


Microsoft Graph DriveItems doc for context
[https://docs.microsoft.com/it-it/onedrive/developer/rest-api/api/driveitem_createuploadsession?view=odsp-graph-online#upload-bytes-to-the-upload-session](https://docs.microsoft.com/it-it/onedrive/developer/rest-api/api/driveitem_createuploadsession?view=odsp-graph-online#upload-bytes-to-the-upload-session)



